### PR TITLE
docs: document Tailwind CSS v4 setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ The `--legacy-peer-deps` flag is required because `eslint-plugin-jsx-a11y@^6` st
 | `npm run format:check` | Check Prettier formatting without writing            |
 | `npm run typecheck`    | Project-references type check (`tsc -b --noEmit`)    |
 
+### Styling
+
+Styling uses [Tailwind CSS v4](https://tailwindcss.com) via the official `@tailwindcss/vite` plugin. There is no PostCSS config and no `tailwind.config.js`; the v4 Vite plugin auto-scans the project for class names.
+
+- Entry stylesheet: `src/index.css` containing a single `@import 'tailwindcss';`
+- The stylesheet is imported once from `src/main.tsx`, so it ships with every page
+- To add styles, write utility classes directly in `className` (e.g. `<h1 className="text-4xl font-bold text-blue-600">`)
+
 ### Git hooks
 
 A pre-commit hook runs `lint-staged` on staged files:


### PR DESCRIPTION
## Summary
- Adds a `### Styling` section to `README.md` (between `### Scripts` and `### Git hooks`) describing the Tailwind CSS v4 setup landed in #2 — the `@tailwindcss/vite` plugin path, the `src/index.css` entry stylesheet, where it's imported, and how to add utility classes.

## Notes
- Documentation-only change; no code, scripts, or config touched.
- This branches off `main`, so the section describes code that does not exist on `main` yet. **Should land after #2 merges** — otherwise the README will reference files (`src/index.css`) that aren't in `main`.

## Test plan
- [x] Prettier (via `lint-staged`) ran clean on the README during commit
- [ ] Visual review of the rendered README on GitHub once the PR is open